### PR TITLE
Fix Issue #3: explicity set the File Write Mode for files saved with …

### DIFF
--- a/BBDecoder.cpp
+++ b/BBDecoder.cpp
@@ -76,6 +76,14 @@ int BBDecoder(const CKBehaviorContext& behcontext)
 		DeleteCKObjectArray(array);
 		throw "fuck";
 	}
+
+	// in files saved with Virtools 3.0+, the Variable Manager setting 
+	// for File Options/Compression is implemented as a File Write Mode, so
+	// the global File Write Mode defaults back to CKFILE_FORVIEWER, and
+	// scripts will be hidden
+	// we correct this by explicity setting the File Write Mode after Loading
+	ctx->SetFileWriteMode((CK_FILE_WRITEMODE)(ctx->GetFileWriteMode() & ~CKFILE_FORVIEWER));
+
 	clock_t c=clock();
 	for (array->Reset(); !array->EndOfList(); array->Next()) {
 		CKObject* o = array->GetData(ctx);


### PR DESCRIPTION
This is a fix for Issue #3 where scripts are hidden in files saved with Virtools 3.0+.

As you likely already know, Virtools distinguishes NMO files from VMO files by using a flag in the **File Info** at the start of the file. This flag, the **File Write Mode,** corresponds to the `CK_FILE_WRITEMODE` enum in CKEnums.h.

A value of 0x00000008 corresponds to the `CKFILE_WHOLECOMPRESSED` flag, which indicates the file is compressed. A value of 0x0000000C corresponds to a combination of the `CKFILE_WHOLECOMPRESSED` (0x00000008) and `CKFILE_FORVIEWER` (0x00000004) flags, the latter of which indicates the file is for viewers only (such as the 3D Life Player.) Modifying a VMO file to remove this flag makes it behave as an NMO file, which allows it to be opened in Virtools (with scripts hidden.)

However, in files saved with Virtools 3.0 and later, the File Write Mode is stored redundantly. In the Variable Manager, there is a setting for File Options/Compression. This setting is implemented by storing the File Write Mode. If the setting is set to Compressed and the file is exported for viewers, then the File Write Mode is stored as 0x0000000C, separately from the flag in the File Info.

As a result, when loading the file - although it does load - the global File Write Mode is set back to `CKFILE_FORVIEWER`, and the scripts are hidden, because their interface is not intended to be accessible within the 3D Life Player. The solution is to explicitly unset the `CKFILE_FORVIEWER` flag in the File Write Mode after loading the file.

Attached is a VMO file - modified into an NMO file - for Hammer: The Game, which may only be decoded with this fix applied.

[hammer_thegame.zip](https://github.com/BearKidsTeam/VirtoolsScriptDeobfuscation/files/10987540/hammer_thegame.zip)
